### PR TITLE
Add code review summary for documentation site

### DIFF
--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,0 +1,18 @@
+# Code review summary
+
+## Overview
+A review of the current jbcom portfolio and ecosystem documentation site built with React, Vite, and Material UI. The app highlights multiple jbcom packages, provides filtering and detail views, and includes WebGL demos powered by React Three Fiber.
+
+## Strengths
+- **Cohesive visual system** – The custom MUI theme defines consistent color tokens, typography families, rounded shapes, and component overrides that align with the design-system brief, giving the site a unified visual language out of the box.【F:src/theme.ts†L1-L195】
+- **Structured ecosystem data** – Package metadata is modeled with clear TypeScript types and a single source of truth array that feeds list and detail experiences, keeping the catalog maintainable and testable.【F:src/data/ecosystem.ts†L1-L200】
+- **Engaging demos** – The demos page showcases multiple 3D scenarios (geometry distortion, particles, floating objects) with tabbed preview/code and navigation between demos, illustrating the capabilities of the strata stack.【F:src/pages/DemosPage.tsx†L1-L200】
+
+## Issues & recommendations
+1. **Duplicated app providers and routers** – `BrowserRouter`, `ThemeProvider`, and `CssBaseline` are rendered in both `src/main.tsx` and `src/App.tsx`, creating nested routers and duplicate theme/reset contexts. This increases bundle work and can lead to unexpected routing behavior. Move the providers to a single entry point (typically `main.tsx`) and render `App` inside them once.【F:src/main.tsx†L1-L16】【F:src/App.tsx†L8-L35】
+2. **Full-page reload in breadcrumbs** – The project detail breadcrumb uses the MUI `Link` with an `href`, which triggers a hard navigation and resets SPA state. Use `react-router-dom`'s `Link`/`RouterLink` (e.g., `component={RouterLink}` with `to="/ecosystem"`) to keep client-side navigation and preserve history state.【F:src/pages/ProjectPage.tsx†L36-L50】
+3. **Missing accessible labels on icon buttons** – Several icon-only buttons (drawer close, hamburger menu, GitHub link) lack `aria-label`, making navigation harder for screen readers. Add descriptive labels such as `aria-label="Open navigation"`, `aria-label="Close navigation"`, and `aria-label="jbcom GitHub"` to the `IconButton` components.【F:src/components/Layout.tsx†L109-L167】
+4. **Blank state while loading demos** – Inside the demo viewer, the `<Suspense>` around the canvas renders `null` while assets load, so users may see an empty area even though the outer page shows a spinner only during initial page-level load. Consider showing a lightweight fallback within the canvas (e.g., a small loading overlay) so demo swaps provide immediate feedback.【F:src/pages/DemosPage.tsx†L168-L200】
+
+## Next steps
+Address the items above to stabilize routing, improve accessibility, and polish perceived performance. After fixes, run the site in a screen reader and on throttled networks to validate the improvements.

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,18 +1,33 @@
-# Code review summary
+# Comprehensive code review
 
-## Overview
-A review of the current jbcom portfolio and ecosystem documentation site built with React, Vite, and Material UI. The app highlights multiple jbcom packages, provides filtering and detail views, and includes WebGL demos powered by React Three Fiber.
+## What I tested
+- `pnpm install` (lockfile already satisfied) to ensure dependencies resolve before running checks.【00cde9†L1-L2】
+- `pnpm lint` → **fails** because Biome wants import reordering/formatting updates in `Layout.tsx`, `AboutPage.tsx`, and `DemosPage.tsx`. No fixes applied yet.【c3a90b†L1-L63】
+- `pnpm typecheck` → **fails** with two `TS2590` "union type too complex" errors originating from the `Box` components that wrap the demo tabs/content in `DemosPage.tsx` (lines 170 and 186).【604597†L1-L15】
 
 ## Strengths
-- **Cohesive visual system** – The custom MUI theme defines consistent color tokens, typography families, rounded shapes, and component overrides that align with the design-system brief, giving the site a unified visual language out of the box.【F:src/theme.ts†L1-L195】
-- **Structured ecosystem data** – Package metadata is modeled with clear TypeScript types and a single source of truth array that feeds list and detail experiences, keeping the catalog maintainable and testable.【F:src/data/ecosystem.ts†L1-L200】
-- **Engaging demos** – The demos page showcases multiple 3D scenarios (geometry distortion, particles, floating objects) with tabbed preview/code and navigation between demos, illustrating the capabilities of the strata stack.【F:src/pages/DemosPage.tsx†L1-L200】
+- **Consistent theming and typography** – The shared theme defines palette tokens, typography ramps, component radius, and MUI overrides that give every page a cohesive look while keeping defaults centralized.【F:src/theme.ts†L1-L195】
+- **Data model is well structured** – Ecosystem content is captured in typed objects with helper accessors (`getFeaturedPackages`, `getPackageById`, stats helpers), which keeps the catalog pages simple and makes it easy to extend or test new entries.【F:src/data/ecosystem.ts†L1-L189】【F:src/data/ecosystem.ts†L400-L420】
+- **Clear content hierarchy** – Pages like Home, About, and Ecosystem use semantic headings, grids, and chips to convey categories and package metadata, which keeps the directory scannable and consistent.【F:src/pages/HomePage.tsx†L5-L116】【F:src/pages/AboutPage.tsx†L71-L143】【F:src/pages/EcosystemPage.tsx†L65-L207】
+- **Engaging demo showcase** – The demos page provides multiple Three.js scenes, tabbed preview/code, and deep links for each demo ID, demonstrating the 3D capabilities of the stack in a developer-friendly format.【F:src/pages/DemosPage.tsx†L7-L213】
 
 ## Issues & recommendations
-1. **Duplicated app providers and routers** – `BrowserRouter`, `ThemeProvider`, and `CssBaseline` are rendered in both `src/main.tsx` and `src/App.tsx`, creating nested routers and duplicate theme/reset contexts. This increases bundle work and can lead to unexpected routing behavior. Move the providers to a single entry point (typically `main.tsx`) and render `App` inside them once.【F:src/main.tsx†L1-L16】【F:src/App.tsx†L8-L35】
-2. **Full-page reload in breadcrumbs** – The project detail breadcrumb uses the MUI `Link` with an `href`, which triggers a hard navigation and resets SPA state. Use `react-router-dom`'s `Link`/`RouterLink` (e.g., `component={RouterLink}` with `to="/ecosystem"`) to keep client-side navigation and preserve history state.【F:src/pages/ProjectPage.tsx†L36-L50】
-3. **Missing accessible labels on icon buttons** – Several icon-only buttons (drawer close, hamburger menu, GitHub link) lack `aria-label`, making navigation harder for screen readers. Add descriptive labels such as `aria-label="Open navigation"`, `aria-label="Close navigation"`, and `aria-label="jbcom GitHub"` to the `IconButton` components.【F:src/components/Layout.tsx†L109-L167】
-4. **Blank state while loading demos** – Inside the demo viewer, the `<Suspense>` around the canvas renders `null` while assets load, so users may see an empty area even though the outer page shows a spinner only during initial page-level load. Consider showing a lightweight fallback within the canvas (e.g., a small loading overlay) so demo swaps provide immediate feedback.【F:src/pages/DemosPage.tsx†L168-L200】
+1) **Duplicate routers/providers** – `BrowserRouter`, `ThemeProvider`, and `CssBaseline` are instantiated in both `main.tsx` and `App.tsx`, creating nested routers and redundant contexts. Consolidate them into a single top-level wrapper (typically in `main.tsx`) and render `App` inside once to avoid double routing and extra renders.【F:src/main.tsx†L1-L16】【F:src/App.tsx†L8-L35】
+
+2) **Typecheck is red** – `pnpm typecheck` fails because MUI infers overly complex union types from the `Box` `sx` props around the tabs and content container in `DemosPage`. Simplify the `sx` objects (e.g., pull them into typed constants or narrow with `SxProps<Theme>`) so the tabs wrapper at line 170 and content container at line 186 no longer explode the union analysis.【F:src/pages/DemosPage.tsx†L165-L213】【604597†L1-L15】
+
+3) **Lint is red** – Biome currently reports import ordering/formatting issues in `Layout.tsx`, `AboutPage.tsx`, and `DemosPage.tsx`. Apply the formatter (`pnpm lint:fix` or `biome check --write .`) to maintain the repo standard and keep diffs small for future contributors.【c3a90b†L1-L63】
+
+4) **Full-page reload in breadcrumbs** – The project detail breadcrumb uses MUI's `Link` with an `href`, causing a hard navigation back to `/ecosystem` and wiping SPA state/history. Swap to `react-router-dom`'s `Link`/`RouterLink` with `to="/ecosystem"` to keep client-side routing smooth.【F:src/pages/ProjectPage.tsx†L37-L49】
+
+5) **Icon buttons lack accessible labels** – Icon-only controls in the layout and profile header have no `aria-label`, so screen readers announce them generically. Add meaningful labels (e.g., "Open navigation", "Close navigation", "GitHub profile", "LinkedIn profile") to the `IconButton` components in the drawer header, app bar, and social links.【F:src/components/Layout.tsx†L109-L167】【F:src/pages/AboutPage.tsx†L52-L67】
+
+6) **Demo viewer blank state during canvas load** – The outer page shows a spinner while loading the selected demo, but the inner `<Suspense>` around the canvas renders `null`, so users see an empty area while assets stream. Provide an inline fallback (small loader/overlay) inside `DemoViewer` to keep feedback consistent during demo swaps.【F:src/pages/DemosPage.tsx†L185-L213】
+
+7) **Navigation polish** – External links that open new tabs (GitHub, npm, PyPI) are missing `rel="noreferrer"` and in some cases use anchor tags instead of router links (e.g., nav drawer GitHub button). Add `rel` for security and consider using MUI's `Link` or `Button` `component={RouterLink}` for internal paths to preserve SPA behavior.【F:src/components/Layout.tsx†L140-L150】【F:src/pages/ProjectPage.tsx†L103-L133】【F:src/pages/HomePage.tsx†L33-L70】
 
 ## Next steps
-Address the items above to stabilize routing, improve accessibility, and polish perceived performance. After fixes, run the site in a screen reader and on throttled networks to validate the improvements.
+- Fix the router/provider duplication, rerun `pnpm typecheck`, and ensure MUI `sx` props in `DemosPage` are typed to pass TS.
+- Run `pnpm lint:fix` to normalize formatting, then address any remaining lint or accessibility warnings.
+- Update breadcrumb/navigation links to use router-aware components and add `aria-label` coverage on all icon-only controls.
+- Add a lightweight canvas fallback in the demo viewer to avoid blank frames when switching demos.


### PR DESCRIPTION
## Summary
- add a written code review covering the jbcom portfolio and ecosystem site
- highlight strengths, issues, and recommended next steps for routing, accessibility, and demo UX

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941415b60bc8322b6c7025d0e1d76da)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a comprehensive code review document summarizing test outcomes, strengths, key issues, and next steps.
> 
> - **Documentation**
>   - Add `docs/CODE_REVIEW.md`:
>     - _What I tested_: `pnpm install`; failing `pnpm lint` (import/format); failing `pnpm typecheck` due to MUI `Box` `sx` union complexity.
>     - _Strengths_: cohesive theming, typed ecosystem data model, clear content hierarchy, engaging demos.
>     - _Issues & recommendations_: duplicate routers/providers; fix typecheck/lint; use SPA breadcrumbs; add `aria-label`s to icon buttons; provide demo canvas fallback; add `rel="noreferrer"` and prefer router-aware links.
>     - _Next steps_: dedupe providers, narrow/typed `sx` props, run formatter, switch to router links, add labels and canvas fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 194b16d3ae0fc37fbe44a69ba9f68afff4423708. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->