### PR TITLE
feat: auto-regenerate resume on PR, fix automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Approve PR
         env:
-          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr review "$PR_URL" --approve
 

--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -1,0 +1,77 @@
+name: Resume Generator
+
+on:
+  pull_request:
+    paths:
+      - 'src/content/resume.json'
+      - 'scripts/generate-resume-*.ts'
+      - 'src/lib/dates.ts'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: resume-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    name: Generate Resume
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright (for resume PDF generation)
+        run: npx playwright install chromium --with-deps
+
+      - name: Generate resume files
+        run: pnpm generate:resume
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet public/Jon_Bogaty_Resume.pdf public/Jon_Bogaty_Resume.docx; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add public/Jon_Bogaty_Resume.pdf public/Jon_Bogaty_Resume.docx
+          git commit -m "chore: regenerate resume PDF and DOCX"
+          git push
+
+      - name: Comment on PR
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'Resume PDF and DOCX have been automatically regenerated from updated source files.'
+            })


### PR DESCRIPTION
## Summary
- Add `resume.yml` workflow: on PRs that change `resume.json` or generator scripts, regenerate PDF/DOCX, commit back to the PR branch if changed, and comment on the PR
- Fix automerge self-approval bug: release-please PRs created by `CI_GITHUB_TOKEN` can't be approved by the same token — switch approval to `GITHUB_TOKEN` (different identity) while keeping PAT for merge

## Why automerge was broken
`CI_GITHUB_TOKEN` (PAT) creates the release-please PR. The automerge workflow then tried to approve the PR using the same PAT → GitHub rejects with "cannot approve your own pull request." Fix: use `GITHUB_TOKEN` (github-actions bot) for approval, PAT only for merge.

## Test plan
- [ ] CI passes (lint, typecheck, build, test)
- [ ] After merge, release-please PR #107 should auto-approve and merge
- [ ] Future resume.json changes in PRs should trigger PDF/DOCX regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)