### PR TITLE
feat: scheduled automerge + resume generator workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,10 @@ jobs:
               .author.login == "dependabot[bot]" or
               .author.login == "release-please[bot]" or
               (.labels | map(.name) | index("autorelease: pending"))
-            ) | .number]')
+            ) | .number]') || {
+            echo "Failed to retrieve PR list"
+            exit 1
+          }
 
           if [ "$prs" = "[]" ] || [ -z "$prs" ]; then
             echo "No eligible PRs found"
@@ -34,8 +37,12 @@ jobs:
             echo "Processing PR #$pr"
 
             # Check if all required CI checks passed
-            checks=$(gh pr checks "$pr" --repo "$GITHUB_REPOSITORY" 2>&1 || true)
-            if echo "$checks" | grep -qE "^(Lint|Typecheck|Build|Test)\s+fail"; then
+            checks=$(gh pr checks "$pr" --repo "$GITHUB_REPOSITORY" --json state,name 2>&1)
+            if [ $? -ne 0 ]; then
+              echo "  Skipping #$pr — unable to retrieve CI status"
+              continue
+            fi
+            if echo "$checks" | jq -e '[.[] | select(.name | test("Lint|Typecheck|Build|Test")) | select(.state != "success")] | length > 0' > /dev/null; then
               echo "  Skipping #$pr — CI checks not passing"
               continue
             fi

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,8 +1,9 @@
 name: Automerge
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: '0 6 * * *' # Daily at 6 AM UTC
+  workflow_dispatch: # Manual trigger
 
 permissions:
   contents: write
@@ -11,28 +12,36 @@ permissions:
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    if: >-
-      github.actor == 'dependabot[bot]' ||
-      github.actor == 'release-please[bot]' ||
-      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     steps:
-      - name: Wait for CI
-        if: github.actor == 'dependabot[bot]'
-        uses: lewagon/wait-on-check-action@a499964d3917700d29a2a8baf3f16b078d609410 # v1.5.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          check-regexp: (Lint|Typecheck|Build|Test)
-          wait-interval: 15
-
-      - name: Approve PR
+      - name: Merge eligible PRs
         env:
           GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr review "$PR_URL" --approve
+        run: |
+          # Find open PRs from dependabot or release-please
+          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,author,labels \
+            --jq '[.[] | select(
+              .author.login == "dependabot[bot]" or
+              .author.login == "release-please[bot]" or
+              (.labels | map(.name) | index("autorelease: pending"))
+            ) | .number]')
 
-      - name: Merge PR
-        env:
-          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge "$PR_URL" --squash --auto
+          if [ "$prs" = "[]" ] || [ -z "$prs" ]; then
+            echo "No eligible PRs found"
+            exit 0
+          fi
+
+          for pr in $(echo "$prs" | jq -r '.[]'); do
+            echo "Processing PR #$pr"
+
+            # Check if all required CI checks passed
+            checks=$(gh pr checks "$pr" --repo "$GITHUB_REPOSITORY" 2>&1 || true)
+            if echo "$checks" | grep -qE "^(Lint|Typecheck|Build|Test)\s+fail"; then
+              echo "  Skipping #$pr — CI checks not passing"
+              continue
+            fi
+
+            # Approve and merge
+            gh pr review "$pr" --repo "$GITHUB_REPOSITORY" --approve || true
+            gh pr merge "$pr" --repo "$GITHUB_REPOSITORY" --squash --auto
+            echo "  Queued #$pr for merge"
+          done

--- a/.github/workflows/resume.yml
+++ b/.github/workflows/resume.yml
@@ -1,0 +1,77 @@
+name: Resume Generator
+
+on:
+  pull_request:
+    paths:
+      - 'src/content/resume.json'
+      - 'scripts/generate-resume-*.ts'
+      - 'src/lib/dates.ts'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: resume-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    name: Generate Resume
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright (for resume PDF generation)
+        run: npx playwright install chromium --with-deps
+
+      - name: Generate resume files
+        run: pnpm generate:resume
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet public/Jon_Bogaty_Resume.pdf public/Jon_Bogaty_Resume.docx; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add public/Jon_Bogaty_Resume.pdf public/Jon_Bogaty_Resume.docx
+          git commit -m "chore: regenerate resume PDF and DOCX"
+          git push
+
+      - name: Comment on PR
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'Resume PDF and DOCX have been automatically regenerated from updated source files.'
+            })


### PR DESCRIPTION
## Summary
- **Automerge**: Replace `pull_request` trigger with nightly `schedule` (6 AM UTC) + `workflow_dispatch`. Runs on default branch context with full secret access — no more empty `CI_GITHUB_TOKEN` on dependabot PRs, no more self-approval failures on release-please PRs.
- **Resume generator**: New workflow triggered by PR changes to `resume.json` or generator scripts. Regenerates PDF/DOCX, commits back to PR branch if changed, comments on PR.

## What was broken
Automerge on `pull_request` event had two fatal issues:
1. Dependabot PRs don't expose repo secrets → `CI_GITHUB_TOKEN` was empty → `gh` CLI failed
2. Release-please PRs created by the PAT couldn't be approved by the same PAT → "cannot approve your own pull request"

## Test plan
- [ ] CI passes
- [ ] After merge, trigger automerge manually via `workflow_dispatch` to process the 8 stuck dependabot PRs
- [ ] Future resume.json changes in PRs trigger PDF/DOCX regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)