### PR TITLE
fix: match dependabot author login format in automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -20,8 +20,8 @@ jobs:
           # Find open PRs from dependabot or release-please
           prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,author,labels \
             --jq '[.[] | select(
-              .author.login == "dependabot[bot]" or
-              .author.login == "release-please[bot]" or
+              (.author.login | test("dependabot")) or
+              (.author.login | test("release-please")) or
               (.labels | map(.name) | index("autorelease: pending"))
             ) | .number]') || {
             echo "Failed to retrieve PR list"


### PR DESCRIPTION
## Summary
- `gh pr list --json author` returns `app/dependabot`, not `dependabot[bot]`
- Switch from exact string match to regex `test("dependabot")` to catch both formats
- Same fix for `release-please`

## Root cause
The automerge workflow found 0 eligible PRs despite 8 open dependabot PRs because the jq filter was checking for `dependabot[bot]` but the API returns `app/dependabot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)