### PR TITLE
chore(dependabot): group minor/patch + fix automerge case-sensitivity bug

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,73 +1,26 @@
-# Dependabot Configuration
-# 
-# DIRECT PUSH MODE: Dependabot pushes directly to main (no PRs)
-# Branch rulesets allow Dependabot to bypass protections
-#
-# Dependabot ignores ecosystems that don't apply to your repo
-
 version: 2
 
 updates:
-  # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "ci"
+    groups:
+      actions-minor:
+        update-types: ["minor", "patch"]
+      actions-major:
+        update-types: ["major"]
 
-  # Docker
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "build"
-
-  # NPM/Node.js
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "deps"
-
-  # Python/pip
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "deps"
-
-  # Go modules
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "deps"
-
-  # Rust/Cargo
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "deps"
-
-  # Terraform
-  - package-ecosystem: "terraform"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "deps"
-
-  # Git submodules
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "deps"
+    groups:
+      npm-minor:
+        update-types: ["minor", "patch"]
+      npm-major:
+        update-types: ["major"]

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -42,7 +42,7 @@ jobs:
               echo "  Skipping #$pr — unable to retrieve CI status"
               continue
             fi
-            if echo "$checks" | jq -e '[.[] | select(.name | test("Lint|Typecheck|Build|Test")) | select(.state != "success")] | length > 0' > /dev/null; then
+            if echo "$checks" | jq -e '[.[] | select(.name | test("Lint|Typecheck|Build|Test")) | select((.state // "") | ascii_downcase != "success")] | length > 0' > /dev/null; then
               echo "  Skipping #$pr — CI checks not passing"
               continue
             fi


### PR DESCRIPTION
## Summary
- Group each ecosystem's minor/patch updates into one PR, keep majors isolated
- Drop unused ecosystems (pip, gomod, cargo, terraform, gitsubmodule, docker) — this repo is TypeScript/Astro only

## Test plan
- [ ] Next dependabot run produces grouped PRs (npm-minor, actions-minor) instead of one PR per package

🤖 Generated with [Claude Code](https://claude.com/claude-code)