### PR TITLE
feat(ci): add Dependabot + safe automerge for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ci

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,29 @@
+name: Automerge
+
+on:
+  pull_request_target:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve and enable auto-merge (patch/minor only)
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review "$PR_URL" --approve
+          gh pr merge "$PR_URL" --squash --auto

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Assert no Node build pipeline
         run: |


### PR DESCRIPTION
## Summary

Consolidates the intent of two stale branches (`ci/scheduled-automerge-and-resume-workflow`, `fix/automerge-author-login`) that predate the static-site rebuild, redesigned for today's architecture rather than mechanically ported.

- Reintroduces automated GitHub Actions dependency updates + automerge — this repo had both before the site was rebuilt as static HTML, but they were removed along with the Node build pipeline they were entangled with.
- Adds `.github/dependabot.yml` scoped to the `github-actions` ecosystem only. The current dependency surface is exactly 4 SHA-pinned actions — there's no npm/pnpm surface to track anymore.
- Adds `.github/workflows/automerge.yml` using `dependabot/fetch-metadata` + native `gh pr merge --auto --squash`, gated by branch protection requiring the `Static site validation` check (now configured on `main`).
- Bumps `actions/checkout` to v7.0.1 (latest patch).

## Why not a mechanical port of the old workflow

The old `automerge.yml` (from the pre-rebuild branches):
- Matched `author.login == "dependabot[bot]"` by regex, which broke when GitHub changed the login format to `"app/dependabot"` — `fix/automerge-author-login` was a patch for that exact fragility. `dependabot/fetch-metadata` replaces this with GitHub's own supported mechanism.
- Grepped `gh pr checks` output for job names matching `Lint|Typecheck|Build|Test`, none of which exist in the current single-job `static-site` CI. Native auto-merge defers to GitHub's required-status-check gating instead of hardcoded job-name matching.
- Required a custom `CI_GITHUB_TOKEN` PAT. The new workflow uses `GITHUB_TOKEN`.
- Auto-merged everything with passing CI, including major bumps. The new workflow excludes major version bumps from automerge — those need manual review.

## Test plan
- [x] YAML validated for all new/changed files
- [x] CI's local-run assertions (`no Node pipeline`, asset presence, no CDN deps) pass unchanged
- [x] Branch protection confirmed active on `main` requiring `Static site validation`
- [ ] CI green on this PR
- [ ] First Dependabot PR (if any) exercises automerge end-to-end
