### PR TITLE
fix(ci): post-merge review fixes — stale CODEOWNERS + automerge hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,5 @@
 # GitHub Actions and CI/CD
 /.github/ @jbdevprimary
 
-# Cursor rules and agent configuration
-/.cursor/ @jbdevprimary
-
 # Documentation
-/docs/ @jbdevprimary
 *.md @jbdevprimary

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependabot:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'jbcom/jbcom.github.io'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata
@@ -19,11 +19,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve and enable auto-merge (patch/minor only)
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+      - name: Enable auto-merge (patch/minor only)
+        if: steps.metadata.outputs.update-type != '' && steps.metadata.outputs.update-type != 'version-update:semver-major'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          gh pr review "$PR_URL" --approve
-          gh pr merge "$PR_URL" --squash --auto
+        run: gh pr merge "$PR_URL" --squash --auto


### PR DESCRIPTION
## Summary

Fixes from a mandatory post-merge review pass on PR #168 (Dependabot + automerge). Two independent findings, verified against live repo state (not just static reading):

**1. Stale CODEOWNERS entries** — `/.cursor/` and `/docs/` don't exist anywhere in the tracked tree (confirmed via `git ls-tree -r HEAD`). Removed; the existing `*` and `*.md` rules already cover everything real.

**2. automerge.yml hardening** — a security-focused review flagged that the job-level gate used `github.actor` (who triggered the event) instead of `github.event.pull_request.user.login` (the actual PR author) — the pattern `dependabot/fetch-metadata`'s own README uses in every example, with a `github.repository ==` guard alongside it. Also added an explicit non-empty check on `update-type` as defense-in-depth, and removed the `gh pr review --approve` step entirely after verifying (via live API) that `main` has no required-review rule at all — `required_pull_request_reviews` is absent from branch protection, and the one active ruleset's rules (`copilot_code_review`, `code_quality`) explicitly exclude `main`. The approval was satisfying no real gate.

## Verification
- [x] Both branch-protection facts (`required_pull_request_reviews` absent, ruleset excludes `main`) reverified live via `gh api` before committing — not taken on the reviewing agent's word alone (one of its other claims about required-review-count was independently found to be incorrect and is not part of this fix)
- [x] `github.event.pull_request.user.login` + `github.repository ==` pattern cross-checked against dependabot/fetch-metadata's README at the pinned SHA
- [x] YAML validated
- [ ] CI green on this PR
